### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ gulp-angular-browserify-seed
 
 A seed project for gulp, angular, and browserify projects.
 
-##Installation
+## Installation
 ```
 
 #install global npm dependencies
@@ -19,7 +19,7 @@ npm install
 bower install
 
 ```
-##Setup
+## Setup
 ```
 #wire angular dependencies with browserify and gulp
 gulp browserify


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
